### PR TITLE
Add path nodes collector params support

### DIFF
--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -156,6 +156,7 @@ type Nodes struct {
 	url    *url.URL
 	all    bool
 	node   string
+	params string
 
 	up                              prometheus.Gauge
 	totalScrapes, jsonParseFailures prometheus.Counter
@@ -169,13 +170,14 @@ type Nodes struct {
 }
 
 // NewNodes defines Nodes Prometheus metrics
-func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool, node string) *Nodes {
+func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool, node string, params string) *Nodes {
 	return &Nodes{
 		logger: logger,
 		client: client,
 		url:    url,
 		all:    all,
 		node:   node,
+		params: params,
 
 		up: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: prometheus.BuildFQName(namespace, "node_stats", "up"),
@@ -1804,9 +1806,9 @@ func (c *Nodes) fetchAndDecodeNodeStats() (nodeStatsResponse, error) {
 	u := *c.url
 
 	if c.all {
-		u.Path = path.Join(u.Path, "/_nodes/stats")
+		u.Path = path.Join(u.Path, "_nodes", "stats", c.params)
 	} else {
-		u.Path = path.Join(u.Path, "_nodes", c.node, "stats")
+		u.Path = path.Join(u.Path, "_nodes", c.node, "stats", c.params)
 	}
 
 	res, err := c.client.Get(u.String())

--- a/collector/nodes_test.go
+++ b/collector/nodes_test.go
@@ -44,7 +44,7 @@ func TestNodesStats(t *testing.T) {
 				t.Fatalf("Failed to parse URL: %s", err)
 			}
 			u.User = url.UserPassword("elastic", "changeme")
-			c := NewNodes(log.NewNopLogger(), http.DefaultClient, u, true, "_local")
+			c := NewNodes(log.NewNopLogger(), http.DefaultClient, u, true, "_local", "")
 			nsr, err := c.fetchAndDecodeNodeStats()
 			if err != nil {
 				t.Fatalf("Failed to fetch or decode node stats: %s", err)

--- a/main.go
+++ b/main.go
@@ -38,6 +38,9 @@ func main() {
 		esNode = kingpin.Flag("es.node",
 			"Node's name of which metrics should be exposed.").
 			Default("_local").Envar("ES_NODE").String()
+		esParams = kingpin.Flag("es.stats.params",
+			"Path parameters limits the information returned to the specific metrics").
+			Default("").Envar("ES_NODES_STATS_PARAMS").String()
 		esExportIndices = kingpin.Flag("es.indices",
 			"Export stats for indices in the cluster.").
 			Default("false").Envar("ES_INDICES").Bool()
@@ -113,7 +116,7 @@ func main() {
 	clusterInfoRetriever := clusterinfo.New(logger, httpClient, esURL, *esClusterInfoInterval)
 
 	prometheus.MustRegister(collector.NewClusterHealth(logger, httpClient, esURL))
-	prometheus.MustRegister(collector.NewNodes(logger, httpClient, esURL, *esAllNodes, *esNode))
+	prometheus.MustRegister(collector.NewNodes(logger, httpClient, esURL, *esAllNodes, *esNode, *esParams))
 
 	if *esExportIndices || *esExportShards {
 		iC := collector.NewIndices(logger, httpClient, esURL, *esExportShards)

--- a/main.go
+++ b/main.go
@@ -59,6 +59,9 @@ func main() {
 		esExportNodesStats = kingpin.Flag("es.stats",
 			"Export nodes stats for the cluster").
 			Default("true").Envar("ES_NODES_STATS").Bool()
+		esExportClusterHealth = kingpin.Flag("es.health",
+			"Export cluster health for the cluster").
+			Default("true").Envar("ES_CLUSTER_HEALTH").Bool()
 		esClusterInfoInterval = kingpin.Flag("es.clusterinfo.interval",
 			"Cluster info update interval for the cluster label").
 			Default("5m").Envar("ES_CLUSTERINFO_INTERVAL").Duration()
@@ -118,7 +121,9 @@ func main() {
 	// cluster info retriever
 	clusterInfoRetriever := clusterinfo.New(logger, httpClient, esURL, *esClusterInfoInterval)
 
-	prometheus.MustRegister(collector.NewClusterHealth(logger, httpClient, esURL))
+	if *esExportClusterHealth {
+		prometheus.MustRegister(collector.NewClusterHealth(logger, httpClient, esURL))
+	}
 
 	if *esExportNodesStats {
 		prometheus.MustRegister(collector.NewNodes(logger, httpClient, esURL, *esAllNodes, *esNode, *esParams))

--- a/main.go
+++ b/main.go
@@ -56,6 +56,9 @@ func main() {
 		esExportSnapshots = kingpin.Flag("es.snapshots",
 			"Export stats for the cluster snapshots.").
 			Default("false").Envar("ES_SNAPSHOTS").Bool()
+		esExportNodesStats = kingpin.Flag("es.stats",
+			"Export nodes stats for the cluster").
+			Default("true").Envar("ES_NODES_STATS").Bool()
 		esClusterInfoInterval = kingpin.Flag("es.clusterinfo.interval",
 			"Cluster info update interval for the cluster label").
 			Default("5m").Envar("ES_CLUSTERINFO_INTERVAL").Duration()
@@ -116,7 +119,10 @@ func main() {
 	clusterInfoRetriever := clusterinfo.New(logger, httpClient, esURL, *esClusterInfoInterval)
 
 	prometheus.MustRegister(collector.NewClusterHealth(logger, httpClient, esURL))
-	prometheus.MustRegister(collector.NewNodes(logger, httpClient, esURL, *esAllNodes, *esNode, *esParams))
+
+	if *esExportNodesStats {
+		prometheus.MustRegister(collector.NewNodes(logger, httpClient, esURL, *esAllNodes, *esNode, *esParams))
+	}
 
 	if *esExportIndices || *esExportShards {
 		iC := collector.NewIndices(logger, httpClient, esURL, *esExportShards)

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/justwatchcom/elasticsearch_exporter/collector"
 	"github.com/justwatchcom/elasticsearch_exporter/pkg/clusterinfo"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/version"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
@@ -174,7 +175,7 @@ func main() {
 	prometheus.MustRegister(clusterInfoRetriever)
 
 	mux := http.DefaultServeMux
-	mux.Handle(*metricsPath, prometheus.Handler())
+	mux.Handle(*metricsPath, promhttp.Handler())
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		_, err = w.Write([]byte(`<html>
 			<head><title>Elasticsearch Exporter</title></head>


### PR DESCRIPTION
Unfortunately, this exporter crashes when used on over 550 nodes or with over 90k active_shards with `--es.all` collection enabled. Obviously it is cheaper to scrape 1 to 3 nodes than 550. Therefore adding a few changes:

First https://github.com/justwatchcom/elasticsearch_exporter/commit/3b77b70688bebd1d6e8671808970565ec4bbaa8d change adds additional path support to /_nodes/stats.
Path addition allows filtering of relevant metrics, e.g.:

```bash
--es.stats.params=adaptive_selection,discovery,fs,http,indices,jvm,os,process,thread_pool,transport
```

This allows having multiple elasticsearch exporters that only return relevant /_nodes/stats:
 - `--es.stats.params=fs`
 - `--es.stats.params=http`
 - etc.

Second https://github.com/justwatchcom/elasticsearch_exporter/commit/a8fc87baa775483ab7df9949b8ed5a9af6cb1ec7 change controls whether to collect `/_nodes/stats` at all.

Third https://github.com/justwatchcom/elasticsearch_exporter/commit/ff1c7ce518d80c56de08c0430af4f3f65485406b change controls whether to collect `/_cluster/health` at all.

Upstream contribution: https://github.com/justwatchcom/elasticsearch_exporter/pull/321